### PR TITLE
Work around python3.5 wheel tag issue.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -4,6 +4,12 @@ pants_version: 1.1.0-rc8
 [python-setup]
 interpreter_requirement: CPython>=2.7
 
+# Pants defaults to 0.24.0 which is missing some fixes for python 3.5
+# tag support, so we upgrade here.
+# See release notes here: https://pypi.python.org/pypi/wheel
+# In particular, 0.25.0
+wheel_version: 0.29.0
+
 [gen.thrift]
 gen_options: hashcode
 deps: ['3rdparty:thrift-0.9.2']


### PR DESCRIPTION
Tested with:

```
$ ./pants binary examples:webserver
$ head -1 dist/webserver.pex 
#!/usr/bin/env python3.5
$ ./dist/webserver.pex 
======== Running on http://0.0.0.0:8080/ ========
(Press CTRL+C to quit)
^C
$
```
